### PR TITLE
Suppress pylint warning for MotionTracker class

### DIFF
--- a/vision_based_lift_analysis/src/motion_tracker.py
+++ b/vision_based_lift_analysis/src/motion_tracker.py
@@ -2,7 +2,7 @@
     motion_tracker.py provides vertical motion tracking
     for rep phase detection in lift analysis
 '''
-
+# pylint: disable=too-few-public-methods
 class MotionTracker:
     '''
         class: Motion_tracker


### PR DESCRIPTION
Added pylint directive to suppress warning for too few public methods as this file needs only 1 public method